### PR TITLE
AL/PC - CS Department Controlled Classroom Search

### DIFF
--- a/src/main/java/edu/ucsb/cs56/ucsb_courses_search/controllers/CSDeptController.java
+++ b/src/main/java/edu/ucsb/cs56/ucsb_courses_search/controllers/CSDeptController.java
@@ -18,6 +18,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.HashSet;
 import java.util.Arrays;
+import java.util.Comparator;
+import java.util.Collections;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -55,9 +57,22 @@ public class CSDeptController {
         List<CourseListingRow> rows = CourseListingRow.fromCourseOfferings(courseOfferings);
         List<CourseListingRow> filteredRows = filter(rows);
 
-        java.util.Collections.sort(filteredRows, (r1, r2) -> {
+        Comparator<CourseListingRow> byBuildingRoom = (r1, r2) -> {
             return r1.getBuildingRoom().compareTo(r2.getBuildingRoom());
-        });
+        };
+
+        Comparator<CourseListingRow> byDays = (r1, r2) -> {
+            // This comparator depends on the format of days that comes from the Courses
+            // API, where days only occur in their place in the string "MTWRFSU".
+            // This comparator must be reversed to get chronological order.
+            return r1.getDays().compareTo(r2.getDays());
+        };
+
+        Comparator<CourseListingRow> byBeginTime = (r1, r2) -> {
+            return r1.getBeginTime().compareTo(r2.getBeginTime());
+        };
+
+        Collections.sort(filteredRows, byBuildingRoom.thenComparing(byDays.reversed()).thenComparing(byBeginTime));
 
         model.addAttribute("cp", cp);
         model.addAttribute("rows", filteredRows);

--- a/src/main/java/edu/ucsb/cs56/ucsb_courses_search/controllers/CSDeptController.java
+++ b/src/main/java/edu/ucsb/cs56/ucsb_courses_search/controllers/CSDeptController.java
@@ -16,6 +16,8 @@ import edu.ucsb.cs56.ucsbapi.academics.curriculums.utilities.Quarter;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.HashSet;
+import java.util.Arrays;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -24,6 +26,8 @@ import org.slf4j.LoggerFactory;
 public class CSDeptController {
 
     private Logger logger = LoggerFactory.getLogger(CSDeptController.class);
+
+    private HashSet<String> classrooms = new HashSet<String>(Arrays.asList("PHELP 3525", "PHELP 3526", "PHELP 2510", "HFH 1132", "HFH 1152"));
 
     @Autowired
     private CurriculumService curriculumService;
@@ -49,11 +53,25 @@ public class CSDeptController {
         List<CourseOffering> courseOfferings = CourseOffering.fromCoursePage(cp);
 
         List<CourseListingRow> rows = CourseListingRow.fromCourseOfferings(courseOfferings);
+        List<CourseListingRow> filteredRows = filter(rows);
 
         model.addAttribute("cp", cp);
-        model.addAttribute("rows", rows);
+        model.addAttribute("rows", filteredRows);
 
         return "csdept/classroom/results";
     }
+
+    public List<CourseListingRow> filter(List<CourseListingRow> rows) {
+        List<CourseListingRow> result = new ArrayList<CourseListingRow>();
+
+        for(CourseListingRow row : rows) {
+            if(classrooms.contains(row.getBuildingRoom())) {
+                result.add(row);
+            }            
+        }
+
+        return result;
+    }
+
 
 }

--- a/src/main/java/edu/ucsb/cs56/ucsb_courses_search/controllers/CSDeptController.java
+++ b/src/main/java/edu/ucsb/cs56/ucsb_courses_search/controllers/CSDeptController.java
@@ -1,0 +1,62 @@
+package edu.ucsb.cs56.ucsb_courses_search.controllers;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+import edu.ucsb.cs56.ucsb_courses_search.CurriculumService;
+import edu.ucsb.cs56.ucsb_courses_search.results.CourseListingRow;
+import edu.ucsb.cs56.ucsb_courses_search.results.CourseOffering;
+import edu.ucsb.cs56.ucsb_courses_search.searches.SearchByDept;
+import edu.ucsb.cs56.ucsbapi.academics.curriculums.v1.classes.Course;
+import edu.ucsb.cs56.ucsbapi.academics.curriculums.v1.classes.CoursePage;
+import edu.ucsb.cs56.ucsbapi.academics.curriculums.utilities.Quarter;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@Controller
+public class CSDeptController {
+
+    private Logger logger = LoggerFactory.getLogger(CSDeptController.class);
+
+    @Autowired
+    private CurriculumService curriculumService;
+
+    @GetMapping("/csdept/search/classroom")
+    public String instructor(Model model, SearchByDept searchByDept) {
+        SearchByDept sbd = new SearchByDept();
+        sbd.setDept("CMPSC");
+        sbd.setCourseLevel("A");
+        model.addAttribute("searchByDept", sbd);
+        return "csdept/classroom/search";
+    }
+
+    @GetMapping("/csdept/search/classroom/results")
+    public String search(@RequestParam(name = "dept", required = true) String dept,
+            @RequestParam(name = "quarter", required = true) String quarter,
+            @RequestParam(name = "courseLevel", required = true) String courseLevel, Model model,
+            SearchByDept searchByDept) {
+        model.addAttribute("dept", dept);
+        model.addAttribute("quarter", quarter);
+        model.addAttribute("courseLevel", courseLevel);
+
+        String json = curriculumService.getJSON(dept, quarter, courseLevel);
+        CoursePage cp = CoursePage.fromJSON(json);
+
+        List<CourseOffering> courseOfferings = CourseOffering.fromCoursePage(cp);
+
+        List<CourseListingRow> rows = CourseListingRow.fromCourseOfferings(courseOfferings);
+
+        model.addAttribute("cp", cp);
+        model.addAttribute("rows", rows);
+
+        return "search/bydept/results";
+    }
+
+}

--- a/src/main/java/edu/ucsb/cs56/ucsb_courses_search/controllers/CSDeptController.java
+++ b/src/main/java/edu/ucsb/cs56/ucsb_courses_search/controllers/CSDeptController.java
@@ -38,15 +38,12 @@ public class CSDeptController {
     }
 
     @GetMapping("/csdept/search/classroom/results")
-    public String search(@RequestParam(name = "dept", required = true) String dept,
-            @RequestParam(name = "quarter", required = true) String quarter,
-            @RequestParam(name = "courseLevel", required = true) String courseLevel, Model model,
+    public String search(@RequestParam(name = "quarter", required = true) String quarter,
+            Model model,
             SearchByDept searchByDept) {
-        model.addAttribute("dept", dept);
         model.addAttribute("quarter", quarter);
-        model.addAttribute("courseLevel", courseLevel);
 
-        String json = curriculumService.getJSON(dept, quarter, courseLevel);
+        String json = curriculumService.getJSON("CMPSC", quarter, "A");
         CoursePage cp = CoursePage.fromJSON(json);
 
         List<CourseOffering> courseOfferings = CourseOffering.fromCoursePage(cp);
@@ -56,7 +53,7 @@ public class CSDeptController {
         model.addAttribute("cp", cp);
         model.addAttribute("rows", rows);
 
-        return "search/bydept/results";
+        return "csdept/classroom/results";
     }
 
 }

--- a/src/main/java/edu/ucsb/cs56/ucsb_courses_search/controllers/CSDeptController.java
+++ b/src/main/java/edu/ucsb/cs56/ucsb_courses_search/controllers/CSDeptController.java
@@ -55,6 +55,10 @@ public class CSDeptController {
         List<CourseListingRow> rows = CourseListingRow.fromCourseOfferings(courseOfferings);
         List<CourseListingRow> filteredRows = filter(rows);
 
+        java.util.Collections.sort(filteredRows, (r1, r2) -> {
+            return r1.getBuildingRoom().compareTo(r2.getBuildingRoom());
+        });
+
         model.addAttribute("cp", cp);
         model.addAttribute("rows", filteredRows);
 

--- a/src/main/java/edu/ucsb/cs56/ucsb_courses_search/results/CourseListingRow.java
+++ b/src/main/java/edu/ucsb/cs56/ucsb_courses_search/results/CourseListingRow.java
@@ -28,6 +28,22 @@ public class CourseListingRow {
     private boolean firstRow;
     private boolean lastRow;
 
+    public boolean isFirstRow() {
+        return this.firstRow;
+    }
+
+    @Override
+    public String toString() {
+        return "{" +
+            " course='" + getCourse() + "'" +
+            ", rowType='" + getRowType() + "'" +
+            ", section='" + getSection() + "'" +
+            ", timeLocation='" + getTimeLocation() + "'" +
+            ", firstRow='" + isFirstRow() + "'" +
+            ", lastRow='" + isLastRow() + "'" +
+            "}";
+    }
+
     public CourseListingRow(Course course, RowType rowType, Section section, TimeLocation timeLocation,
             boolean firstRow, boolean lastRow) {
         this.course = course;
@@ -165,6 +181,14 @@ public class CourseListingRow {
 
     public void setLastRow(boolean lastRow) {
         this.lastRow = lastRow;
+    }
+
+    public String getBuildingRoom() {
+        if(this.timeLocation == null) {
+            return "";
+        }
+
+        return this.getTimeLocation().building + " " + this.getTimeLocation().room;
     }
 
 }

--- a/src/main/java/edu/ucsb/cs56/ucsb_courses_search/results/CourseListingRow.java
+++ b/src/main/java/edu/ucsb/cs56/ucsb_courses_search/results/CourseListingRow.java
@@ -191,4 +191,20 @@ public class CourseListingRow {
         return this.getTimeLocation().building + " " + this.getTimeLocation().room;
     }
 
+    public String getDays() {
+        if(this.timeLocation == null) {
+            return "";
+        }
+
+        return this.getTimeLocation().days;
+    }
+
+    public String getBeginTime() {
+        if(this.timeLocation == null) {
+            return "";
+        }
+
+        return this.getTimeLocation().beginTime;
+    }
+
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,8 +1,8 @@
-server.port: ${PORT:8081}
+server.port: ${PORT:8080}
 logging.level.org.springframework.web: DEBUG
 spring.security.oauth2.client.registration.github.scope: user,read:org
 ucsb.api.consumer_key: dummy_value_for_tests
-app_github_org: ucsb-cs56-f19
+app_github_org: ucsb-cs56-w20
 
 spring.output.ansi.enabled=DETECT
 logging.level.org.hibernate.SQL=debug

--- a/src/main/resources/templates/csdept/classroom/fragments/form.html
+++ b/src/main/resources/templates/csdept/classroom/fragments/form.html
@@ -1,0 +1,27 @@
+<form method="GET"  th:object="${searchByDept}">
+    <div class="form-group row">
+        <label for="quarter" class="col-sm-2 col-form-label">Quarter</label>
+        <div class="col-sm-10">
+            <select th:field="*{quarter}" class="custom-select">
+                <option selected="selected" value="20201">WINTER 2020</option>
+                <option selected="selected" value="20194">FALL 2019 </option>
+                <option value="20193">SUMMER 2019 </option>
+                <option value="20192">SPRING 2019 </option>
+                <option value="20191">WINTER 2019 </option>
+                <option value="20184">FALL 2018 </option>
+                <option value="20183">SUMMER 2018 </option>
+                <option value="20182">SPRING 2018 </option>
+                <option value="20181">WINTER 2018 </option>
+                <option value="20174">FALL 2017 </option>
+            </select>
+        </div>
+    </div>
+    <div class="form-group row">
+        <label for="js-course-search-submit" class="col-sm-2 col-form-label"></label>
+        <div class="col-sm-10">
+            <button type="submit" th:formaction="@{/search/bydept/results}" class="btn btn-primary" id="js-course-search-submit">Find Courses</button>
+        </div>
+    </div>
+
+    
+</form>

--- a/src/main/resources/templates/csdept/classroom/fragments/form.html
+++ b/src/main/resources/templates/csdept/classroom/fragments/form.html
@@ -19,7 +19,7 @@
     <div class="form-group row">
         <label for="js-course-search-submit" class="col-sm-2 col-form-label"></label>
         <div class="col-sm-10">
-            <button type="submit" th:formaction="@{/search/bydept/results}" class="btn btn-primary" id="js-course-search-submit">Find Courses</button>
+            <button type="submit" th:formaction="@{/csdept/search/classroom/results}" class="btn btn-primary" id="js-course-search-submit">Find Courses</button>
         </div>
     </div>
 

--- a/src/main/resources/templates/csdept/classroom/fragments/list.html
+++ b/src/main/resources/templates/csdept/classroom/fragments/list.html
@@ -1,0 +1,42 @@
+<h2>Courses</h2>
+
+<style>
+  tr.firstRowForCourse { border-top: solid black 2px;}
+  tr.lastRowForCourse { border-bottom: solid black 2px;}
+  tr.SECONDARY td.section { padding-left: 2em; }
+  tr.SECONDARY td.enrollCode { padding-left: 2em; }
+  tr.SECONDARY td.instructorList { padding-left: 2em; }
+
+
+</style>
+
+<table class="table">
+  <thead>
+    <tr>
+      <th>Course Id</th>
+      <th>Title</th>
+      <th>Section</th>
+      <th>Instructor</th>
+      <th>Enroll Cd</th>
+      <th>Days</th>
+      <th>Time</th>
+      <th>Location</th>
+      <th>Enrolled</th>
+      <th>Capacity</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr th:each="r: ${rows}" th:class="(${r.firstRow} ? 'firstRowForCourse' : '') + ' ' + (${r.lastRow} ? 'lastRowForCourse' : '') + ' ' + ${r.rowType}" >
+      <td th:text="${r.course.courseId}"></td>
+      <td th:text="${r.course.title}"></td>
+      <td class="section" th:text="${r.section.section}"></td>
+      <td class="instructorList" th:text="${r.section.instructorList()}"></td>
+      <td class="enrollCode" th:text="${r.section.enrollCode}"></td>
+      <td th:text="${r.timeLocation?.days}"></td>
+      <td th:text="${r.timeLocation == null} ? '' : ${r.timeLocation?.beginTime}+' - '+${r.timeLocation?.endTime}"></td>
+      <td th:text="${r.timeLocation == null} ? '' : ${r.timeLocation?.building}+' '+${r.timeLocation?.room}"></td>
+      <td th:text="${r.section.enrolledTotal}"></td>
+      <td th:text="${r.section.maxEnroll}"></td>
+    </tr>
+  </tbody>
+</table>

--- a/src/main/resources/templates/csdept/classroom/fragments/title.html
+++ b/src/main/resources/templates/csdept/classroom/fragments/title.html
@@ -1,0 +1,3 @@
+<h1>Search For Courses in CS Department Controlled Classrooms</h1>
+<p>This page allows you to search for all courses offered in CS department controlled classrooms in a specific quarter.
+</p>

--- a/src/main/resources/templates/csdept/classroom/results.html
+++ b/src/main/resources/templates/csdept/classroom/results.html
@@ -2,7 +2,7 @@
 <html xmlns:th="http://www.thymeleaf.org" lang="en">
 
 <head>
-  <title>Search For Courses in CS Department Classrooms</title>
+  <title>Search By Department</title>
   <div th:replace="fragments/bootstrap_head.html"></div>
 </head>
 
@@ -12,6 +12,7 @@
 
     <div th:replace="csdept/classroom/fragments/title.html"></div>
     <div th:replace="csdept/classroom/fragments/form.html"></div>
+    <div th:replace="search/bydept/fragments/list.html"></div>
 
     <div th:replace="fragments/bootstrap_footer.html"></div>
   </div>

--- a/src/main/resources/templates/csdept/classroom/results.html
+++ b/src/main/resources/templates/csdept/classroom/results.html
@@ -12,7 +12,7 @@
 
     <div th:replace="csdept/classroom/fragments/title.html"></div>
     <div th:replace="csdept/classroom/fragments/form.html"></div>
-    <div th:replace="search/bydept/fragments/list.html"></div>
+    <div th:replace="csdept/classroom/fragments/list.html"></div>
 
     <div th:replace="fragments/bootstrap_footer.html"></div>
   </div>

--- a/src/main/resources/templates/csdept/classroom/search.html
+++ b/src/main/resources/templates/csdept/classroom/search.html
@@ -1,0 +1,49 @@
+<!DOCTYPE HTML>
+<html xmlns:th="http://www.thymeleaf.org" lang="en">
+
+<head>
+  <title>Search For Courses in CS Department Classrooms</title>
+  <div th:replace="fragments/bootstrap_head.html"></div>
+</head>
+
+<body>
+  <div class="container">
+    <div th:replace="fragments/bootstrap_nav_header.html"></div>
+
+    <!-- <div th:replace="search/csdept/classroom/fragments/title.html"></div> -->
+    <h1>Search For Courses in CS Department Controlled Classrooms</h1>
+    <p>This page allows you to search for all courses offered in CS department controlled classrooms in a specific quarter.
+    </p>
+    <!-- <div th:replace="search/csdept/classroom/fragments/form.html"></div> -->
+    <form method="GET"  th:object="${searchByDept}">
+      <div class="form-group row">
+          <label for="quarter" class="col-sm-2 col-form-label">Quarter</label>
+          <div class="col-sm-10">
+              <select th:field="*{quarter}" class="custom-select">
+                  <option selected="selected" value="20201">WINTER 2020</option>
+                  <option selected="selected" value="20194">FALL 2019 </option>
+                  <option value="20193">SUMMER 2019 </option>
+                  <option value="20192">SPRING 2019 </option>
+                  <option value="20191">WINTER 2019 </option>
+                  <option value="20184">FALL 2018 </option>
+                  <option value="20183">SUMMER 2018 </option>
+                  <option value="20182">SPRING 2018 </option>
+                  <option value="20181">WINTER 2018 </option>
+                  <option value="20174">FALL 2017 </option>
+              </select>
+          </div>
+      </div>
+      <div class="form-group row">
+          <label for="js-course-search-submit" class="col-sm-2 col-form-label"></label>
+          <div class="col-sm-10">
+              <button type="submit" th:formaction="@{/search/bydept/results}" class="btn btn-primary" id="js-course-search-submit">Find Courses</button>
+          </div>
+      </div>
+  </form>
+
+    <div th:replace="fragments/bootstrap_footer.html"></div>
+  </div>
+  <div th:replace="fragments/bootstrap_scripts.html"></div>
+</body>
+
+</html>

--- a/src/main/resources/templates/fragments/bootstrap_nav_header.html
+++ b/src/main/resources/templates/fragments/bootstrap_nav_header.html
@@ -44,6 +44,15 @@
         </div>
       </li>
 
+      <li class="nav-item dropdown">
+        <a class="nav-link dropdown-toggle" href="#" id="navbarDropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+          CS Department
+        </a>
+        <div class="dropdown-menu" aria-labelledby="navbarDropdown">
+          <a class="dropdown-item" href="/csdept/search/classroom">Dept. Classroom Search</a>
+        </div>
+      </li>
+
       <!-- Copy/paste this template when adding additional menu items -->
       <!--
               <li class="nav-item dropdown">

--- a/src/test/java/edu/ucsb/cs56/ucsb_courses_search/csdept/CSDeptTest.java
+++ b/src/test/java/edu/ucsb/cs56/ucsb_courses_search/csdept/CSDeptTest.java
@@ -1,0 +1,122 @@
+package edu.ucsb.cs56.ucsb_courses_search.csdept;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+// import static org.hamcrest.Matchers.equalTo;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.MediaType;
+import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.web.WebAppConfiguration;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+
+import edu.ucsb.cs56.ucsb_courses_search.AuthControllerAdvice;
+import edu.ucsb.cs56.ucsb_courses_search.BootstrapTestHelper;
+import edu.ucsb.cs56.ucsb_courses_search.NavigationTestHelper;
+import edu.ucsb.cs56.ucsb_courses_search.controllers.CSDeptController;
+import edu.ucsb.cs56.ucsb_courses_search.entities.Course;
+import edu.ucsb.cs56.ucsb_courses_search.repositories.CourseRepository;
+import edu.ucsb.cs56.ucsb_courses_search.CurriculumService;
+
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.xpath;
+
+import java.util.List;
+import java.util.ArrayList;
+
+import edu.ucsb.cs56.ucsb_courses_search.OAuthUtils;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.security.test.context.support.WithMockUser;
+
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
+
+import org.junit.Before;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.mock;
+
+@RunWith(SpringRunner.class)
+@WebMvcTest(CSDeptController.class)
+@WebAppConfiguration
+public class CSDeptTest {
+
+    private Logger logger = LoggerFactory.getLogger(CSDeptTest.class);
+
+    @Autowired
+    private MockMvc mvc;
+
+    @MockBean
+    private AuthControllerAdvice aca;
+
+    @MockBean
+    private ClientRegistrationRepository crr;
+
+    @MockBean
+    private CourseRepository mockCourseRepository;
+
+    @MockBean
+    private CurriculumService mockCurriculumService;
+
+    private Authentication mockAuthentication;
+
+    private static final String URL = "/csdept/search/classroom";
+
+    /**
+     * Set up an OAuth mock user so that we can unit test protected endpoints
+     */
+    @Before
+    public void setUp() {
+        OAuth2User principal = OAuthUtils.createOAuth2User("Chris Gaucho", "cgaucho@example.com");
+        mockAuthentication = OAuthUtils.getOauthAuthenticationFor(principal);
+        List<Course> emptyCourseList = new ArrayList<Course>();
+        when(mockCourseRepository.findAll()).thenReturn(emptyCourseList);
+    }
+
+    @Test
+    @WithMockUser
+    public void getClassroomSearch_ContentType() throws Exception {
+        logger.info("mockAuthentication=" + mockAuthentication);
+        mvc.perform(MockMvcRequestBuilders.get(URL).with(authentication(mockAuthentication))
+                .accept(MediaType.TEXT_HTML)).andExpect(status().isOk())
+                .andExpect(content().contentType("text/html;charset=UTF-8"));
+    }
+
+    @Test
+    @WithMockUser
+    public void getClassroomSearch_BootstrapLoaded() throws Exception {
+        BootstrapTestHelper.bootstrapIsLoaded(mvc, URL, mockAuthentication);
+    }
+
+    @Test
+    @WithMockUser
+    public void getClassroomSearch_hasCorrectTitle() throws Exception {
+        mvc.perform(
+                MockMvcRequestBuilders.get(URL).accept(MediaType.TEXT_HTML).with(authentication(mockAuthentication)))
+                .andExpect(status().isOk()).andExpect(xpath("//title").exists())
+                .andExpect(xpath("//title").string("Search For Courses in CS Department Classrooms"));
+    }
+
+    @Test
+    @WithMockUser
+    public void getClassroomSearch_hasNavBar() throws Exception {
+        NavigationTestHelper.hasNavBar(mvc, URL, mockAuthentication);
+    }
+
+    @Test
+    @WithMockUser
+    public void getClassroomSearch_hasFooter() throws Exception {
+        NavigationTestHelper.hasFooter(mvc, URL, mockAuthentication);
+    }
+
+}


### PR DESCRIPTION
In this PR, we add a new menu for CS-department specific functions, and a menu option to list all course meetings that take place in department-controlled classrooms. 

Currently, the list is hard-coded. Future work should move this to an `application.properties` value and print the list of department-controlled classrooms in the header of the page.