### PR TITLE
pc - add github actions for ucsb-courses-search

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -1,0 +1,17 @@
+name: Java CI
+
+on: [push]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v1
+    - name: Set up JDK 11
+      uses: actions/setup-java@v1
+      with:
+        java-version: 11.0.x
+    - name: Build with Maven
+      run: mvn -B test


### PR DESCRIPTION
In this PR, we set up GitHub Actions as the CI system for this project.

Moving forward, we'll remove Travis-CI