### PR TITLE
pc - remove .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,2 +1,0 @@
-language: java
-jdk: oraclejdk11


### PR DESCRIPTION
This commit removes .travis.yml because we are no longer going to use Travis-CI as our CI system;
we've switching to GitHub actions