### PR TITLE
pc - mark searchResults.html as deprecated

### DIFF
--- a/src/main/resources/templates/searchResults.html
+++ b/src/main/resources/templates/searchResults.html
@@ -11,6 +11,21 @@
     <div th:replace="fragments/bootstrap_nav_header.html"></div>
     <h1>Search Results</h1>
 
+    <!--
+
+      N O T I C E   !!!!!
+
+      This view is D E P R E C A T E D
+
+      Please DO NOT add any new features to this view.
+
+      Instead, migrate features from this view into the views
+      at resources/templates/search/bydept/search.html 
+      at resources/templates/search/bydept/results.html 
+      at resources/templates/search/bydept/fragments/... 
+
+    -->
+
     <table class="table">
       <thead>
         <tr>


### PR DESCRIPTION
In this PR, we mark the old  search results view as deprecated.

Programmers should add features to the new byDept view and the search on the home page should go away.

