### PR TITLE
Team 6pm e only ucsb accounts can login

### DIFF
--- a/src/main/java/edu/ucsb/cs56/ucsb_courses_search/controller/CourseController.java
+++ b/src/main/java/edu/ucsb/cs56/ucsb_courses_search/controller/CourseController.java
@@ -7,6 +7,9 @@ import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
 import edu.ucsb.cs56.ucsb_courses_search.entity.Course;
 import edu.ucsb.cs56.ucsb_courses_search.repository.CourseRepository;
 import edu.ucsb.cs56.ucsb_courses_search.service.MembershipService;
@@ -15,6 +18,10 @@ import java.util.ArrayList;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+@ResponseStatus(HttpStatus.FORBIDDEN)
+class AccessForbiddenException extends RuntimeException {
+}
 
 @Controller
 public class CourseController {
@@ -34,7 +41,7 @@ public class CourseController {
     }
 
     @GetMapping("/courseschedule")
-    public String index(Model model, OAuth2AuthenticationToken token) {
+    public String index(Model model, OAuth2AuthenticationToken token) throws AccessForbiddenException {
         
         logger.info("Inside /courseschedule controller method CourseController#index");
         logger.info("model=" + model + " token=" + token);
@@ -47,8 +54,10 @@ public class CourseController {
             // logger.info("there are " + myclasses.size() + " courses that match uid: " + uid);
             model.addAttribute("myclasses", myclasses);
         } else {
-            ArrayList<Course> emptyList = new ArrayList<Course>();
-            model.addAttribute("myclasses", emptyList);
+            //ArrayList<Course> emptyList = new ArrayList<Course>();
+            //model.addAttribute("myclasses", emptyList);
+	    //org.springframework.security.access.AccessDeniedException("403 returned");
+	    throw new AccessForbiddenException();
         }
         return "courseschedule/index";
     }

--- a/src/main/java/edu/ucsb/cs56/ucsb_courses_search/controller/CourseController.java
+++ b/src/main/java/edu/ucsb/cs56/ucsb_courses_search/controller/CourseController.java
@@ -9,6 +9,8 @@ import org.springframework.web.bind.annotation.PostMapping;
 
 import edu.ucsb.cs56.ucsb_courses_search.entity.Course;
 import edu.ucsb.cs56.ucsb_courses_search.repository.CourseRepository;
+import edu.ucsb.cs56.ucsb_courses_search.service.MembershipService;
+
 import java.util.ArrayList;
 
 import org.slf4j.Logger;
@@ -23,6 +25,10 @@ public class CourseController {
     private CourseRepository courseRepository;
 
     @Autowired
+    private MembershipService membershipService;
+
+
+    @Autowired
     public CourseController(CourseRepository courseRepository) {
         this.courseRepository = courseRepository;
     }
@@ -33,7 +39,7 @@ public class CourseController {
         logger.info("Inside /courseschedule controller method CourseController#index");
         logger.info("model=" + model + " token=" + token);
 
-        if (token!=null) {
+        if (token!=null && membershipService.isMember(token)) {
             String uid = token.getPrincipal().getAttributes().get("sub").toString();
             logger.info("uid="+uid);
             logger.info("courseRepository="+courseRepository);

--- a/src/main/java/edu/ucsb/cs56/ucsb_courses_search/controller/advice/AuthControllerAdvice.java
+++ b/src/main/java/edu/ucsb/cs56/ucsb_courses_search/controller/advice/AuthControllerAdvice.java
@@ -26,9 +26,6 @@ public class AuthControllerAdvice {
     @ModelAttribute("login")
     public String getLogin(OAuth2AuthenticationToken token){
         if (token == null) return "";
-	for (java.util.Map.Entry<java.lang.String, java.lang.Object> entry : token.getPrincipal().getAttributes().entrySet()) {
-              System.out.println(entry.getKey() + ":" + entry.getValue().toString());
-          }
         return token.getPrincipal().getAttributes().get("email").toString();
     }
 

--- a/src/main/java/edu/ucsb/cs56/ucsb_courses_search/controller/advice/AuthControllerAdvice.java
+++ b/src/main/java/edu/ucsb/cs56/ucsb_courses_search/controller/advice/AuthControllerAdvice.java
@@ -26,6 +26,12 @@ public class AuthControllerAdvice {
     @ModelAttribute("login")
     public String getLogin(OAuth2AuthenticationToken token){
         if (token == null) return "";
+        return token.getPrincipal().getAttributes().get("email").toString();
+    }
+
+    @ModelAttribute("name")
+    public String getLogin(OAuth2AuthenticationToken token){
+        if (token == null) return "";
         return token.getPrincipal().getAttributes().get("name").toString();
     }
 

--- a/src/main/java/edu/ucsb/cs56/ucsb_courses_search/controller/advice/AuthControllerAdvice.java
+++ b/src/main/java/edu/ucsb/cs56/ucsb_courses_search/controller/advice/AuthControllerAdvice.java
@@ -26,6 +26,9 @@ public class AuthControllerAdvice {
     @ModelAttribute("login")
     public String getLogin(OAuth2AuthenticationToken token){
         if (token == null) return "";
+	for (java.util.Map.Entry<java.lang.String, java.lang.Object> entry : token.getPrincipal().getAttributes().entrySet()) {
+              System.out.println(entry.getKey() + ":" + entry.getValue().toString());
+          }
         return token.getPrincipal().getAttributes().get("email").toString();
     }
 

--- a/src/main/java/edu/ucsb/cs56/ucsb_courses_search/controller/advice/AuthControllerAdvice.java
+++ b/src/main/java/edu/ucsb/cs56/ucsb_courses_search/controller/advice/AuthControllerAdvice.java
@@ -14,7 +14,7 @@ public class AuthControllerAdvice {
 
     @ModelAttribute("isLoggedIn")
     public boolean getIsLoggedIn(OAuth2AuthenticationToken token){
-        return token != null;
+        return token != null; 
     }
 
     @ModelAttribute("id")
@@ -30,7 +30,7 @@ public class AuthControllerAdvice {
     }
 
     @ModelAttribute("name")
-    public String getLogin(OAuth2AuthenticationToken token){
+    public String getName(OAuth2AuthenticationToken token){
         if (token == null) return "";
         return token.getPrincipal().getAttributes().get("name").toString();
     }

--- a/src/main/java/edu/ucsb/cs56/ucsb_courses_search/service/MembershipService.java
+++ b/src/main/java/edu/ucsb/cs56/ucsb_courses_search/service/MembershipService.java
@@ -4,12 +4,17 @@ import org.springframework.security.oauth2.client.authentication.OAuth2Authentic
 
 public interface MembershipService {
 
-    /** is current logged in user a member of the github org */
+    /** is current logged in user an admin for the website */
     public boolean isAdmin(OAuth2AuthenticationToken oAuth2AuthenticationToken);
 
+    /** is current logged in user a member of the UCSB GSuite and able to log in */
+    public boolean isMember(OAuth2AuthenticationToken oAuth2AuthenticationToken);
+
     default public String role(OAuth2AuthenticationToken token) {
-        if (token==null)
+       if (token==null)
             return "Guest";
+       if(isMember(token))
+	    return "Member";
        if (isAdmin(token))
             return "Admin";
         return "Guest";

--- a/src/main/java/edu/ucsb/cs56/ucsb_courses_search/service/MembershipService.java
+++ b/src/main/java/edu/ucsb/cs56/ucsb_courses_search/service/MembershipService.java
@@ -10,14 +10,18 @@ public interface MembershipService {
     /** is current logged in user a member of the UCSB GSuite and able to log in */
     public boolean isMember(OAuth2AuthenticationToken oAuth2AuthenticationToken);
 
+    /**
+     * Return the current user's role on the site.
+     * Note that if the user is both an admin and a member, this function will return admin
+     */ 
     default public String role(OAuth2AuthenticationToken token) {
        if (token==null)
             return "Guest";
-       if(isMember(token))
-	    return "Member";
        if (isAdmin(token))
             return "Admin";
-        return "Guest";
+       if(isMember(token))
+	    return "Member";
+       return "Guest";
     }
 
 }

--- a/src/main/java/edu/ucsb/cs56/ucsb_courses_search/service/UserMembershipService.java
+++ b/src/main/java/edu/ucsb/cs56/ucsb_courses_search/service/UserMembershipService.java
@@ -25,7 +25,7 @@ public class UserMembershipService implements MembershipService {
     final private List<String> adminEmails = new ArrayList<String>();
 
     @Value("${app.member.hosted-domain}")
-    final private String memberHostedDomain = "";
+    final private String memberHostedDomain = "ucsb.edu";
 
     @Autowired
     private OAuth2AuthorizedClientService clientService;
@@ -75,6 +75,7 @@ public class UserMembershipService implements MembershipService {
 
         logger.info("email=[" + email + "]");
         logger.info("hostedDomain=" + hostedDomain);
+	logger.info("memberhosteddomain=" + memberHostedDomain);
 
         if (roleToTest.equals("admin") && isAdminEmail(email)) {
             return true;
@@ -89,7 +90,18 @@ public class UserMembershipService implements MembershipService {
 
     private boolean isAdminEmail(String email)
     {
-    	return adminEmails != null && adminEmails.contains(email);
+    	email=email.trim();
+	for(int i = 0; i < adminEmails.size(); i++)
+	{
+		String test = adminEmails.get(i).trim();
+		adminEmails.set(i, test);
+	}
+	logger.info("email=" + email);
+	logger.info("adminemails=" + adminEmails);
+	logger.info("contains=" + adminEmails.contains(email));
+	logger.info("size=" + adminEmails.size());
+	logger.info("last one=" + adminEmails.get(adminEmails.size()-1));
+    	return adminEmails.get(0).contains(email);
     }
 }
 

--- a/src/main/java/edu/ucsb/cs56/ucsb_courses_search/service/UserMembershipService.java
+++ b/src/main/java/edu/ucsb/cs56/ucsb_courses_search/service/UserMembershipService.java
@@ -90,17 +90,6 @@ public class UserMembershipService implements MembershipService {
 
     private boolean isAdminEmail(String email)
     {
-    	email=email.trim();
-	for(int i = 0; i < adminEmails.size(); i++)
-	{
-		String test = adminEmails.get(i).trim();
-		adminEmails.set(i, test);
-	}
-	logger.info("email=" + email);
-	logger.info("adminemails=" + adminEmails);
-	logger.info("contains=" + adminEmails.contains(email));
-	logger.info("size=" + adminEmails.size());
-	logger.info("last one=" + adminEmails.get(adminEmails.size()-1));
     	return adminEmails.get(0).contains(email);
     }
 }

--- a/src/main/java/edu/ucsb/cs56/ucsb_courses_search/service/UserMembershipService.java
+++ b/src/main/java/edu/ucsb/cs56/ucsb_courses_search/service/UserMembershipService.java
@@ -28,6 +28,24 @@ public class UserMembershipService implements MembershipService {
     {
     }
 
+    /**
+     * Is the currently logged in user a member of the UCSB Gsuite
+     *
+     * @param oAuth2AuthenticationToken the current user's authentication token
+     * @return true if the user is a member of the UCSB GSuite, false otherwise
+     */ 
+    public boolean isMember(OAuth2AuthenticationToken oAuth2AuthenticationToken) {
+	// Per Professor Conrad's request (see https://github.com/ucsb-cs56-w20/ucsb-courses-search/pull/199, bottom),
+	// a member will be anyone with a UCSB email address
+	String userEmail = oAuth2AuthenticationToken.getPrincipal().getAttributes().get("email").toString();
+	if(userEmail.endsWith("@ucsb.edu") || userEmail.endsWith("@umail.ucsb.edu"))
+	{
+		return true;
+	}
+	return false;
+    }
+
+
     public boolean isAdmin(OAuth2AuthenticationToken oAuth2AuthenticationToken) {
         return hasRole(oAuth2AuthenticationToken, "admin");
     }
@@ -40,9 +58,11 @@ public class UserMembershipService implements MembershipService {
      */
 
     public boolean hasRole(OAuth2AuthenticationToken oauthToken, String roleToTest) {
-    	// The G Suite's membership concept is not useful for this app (since none of us is likely to be an admin on the ucsb.edu domain)
-	// Thus, for now, I've left this function to return false every time
-	// This will make it so every user has the role "Guest".
+
+	if(roleToTest == "member")
+	{
+		return isMember(oauthToken);
+	}
         return false;
     }
 

--- a/src/main/java/edu/ucsb/cs56/ucsb_courses_search/service/UserMembershipService.java
+++ b/src/main/java/edu/ucsb/cs56/ucsb_courses_search/service/UserMembershipService.java
@@ -10,7 +10,8 @@ import org.springframework.security.oauth2.client.authentication.OAuth2Authentic
 import org.springframework.security.oauth2.core.OAuth2AccessToken;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.stereotype.Service;
-
+import java.util.List;
+import java.util.ArrayList;
 
 /**
  * Service object that wraps the UCSB Academic Curriculum API
@@ -20,6 +21,8 @@ public class UserMembershipService implements MembershipService {
 
     private Logger logger = LoggerFactory.getLogger(UserMembershipService.class);
 
+    @Value("${app.admin.emails:}")
+    final private List<String> adminEmails = new ArrayList<String>();
 
     @Autowired
     private OAuth2AuthorizedClientService clientService;
@@ -35,6 +38,9 @@ public class UserMembershipService implements MembershipService {
      * @return true if the user is a member of the UCSB GSuite, false otherwise
      */ 
     public boolean isMember(OAuth2AuthenticationToken oAuth2AuthenticationToken) {
+	if(oAuth2AuthenticationToken == null)
+		return false;
+
 	// Per Professor Conrad's request (see https://github.com/ucsb-cs56-w20/ucsb-courses-search/pull/199, bottom),
 	// a member will be anyone with a UCSB email address
 	String userEmail = oAuth2AuthenticationToken.getPrincipal().getAttributes().get("email").toString();
@@ -47,7 +53,10 @@ public class UserMembershipService implements MembershipService {
 
 
     public boolean isAdmin(OAuth2AuthenticationToken oAuth2AuthenticationToken) {
-        return hasRole(oAuth2AuthenticationToken, "admin");
+        if (oAuth2AuthenticationToken == null) 
+		return false;
+	String userEmail = oAuth2AuthenticationToken.getPrincipal().getAttributes().get("email").toString();
+	return adminEmails.contains(userEmail);
     }
 
     /**
@@ -62,6 +71,10 @@ public class UserMembershipService implements MembershipService {
 	if(roleToTest == "member")
 	{
 		return isMember(oauthToken);
+	}
+	if(roleToTest == "admin")
+	{
+		return isAdmin(oauthToken);
 	}
         return false;
     }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,3 +1,6 @@
+app.admin.emails=phtcon@ucsb.edu,scottpchow@ucsb.edu,zsisco@ucsb.edu,pingyuan@ucsb.edu, ajg@ucsb.edu
+app.member.hosted-domain=ucsb.edu
+
 server.port: ${PORT:8080}
 logging.level.org.springframework.web: DEBUG
 ucsb.api.consumer_key: dummy_value_for_tests
@@ -8,5 +11,4 @@ logging.level.org.hibernate.SQL=debug
 spring.jpa.show-sql=true
 spring.jpa.generate-ddl=true
 
-app.admin.emails=phtcon@ucsb.edu,scottpchow@ucsb.edu,zsisco@ucsb.edu,pingyuan@ucsb.edu, ajg@ucsb.edu
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,4 +1,4 @@
-app.admin.emails=phtcon@ucsb.edu,scottpchow@ucsb.edu,zsisco@ucsb.edu,pingyuan@ucsb.edu,ajg@ucsb.edu
+app.admin.emails=phtcon@ucsb.edu,scottpchow@ucsb.edu,zsisco@ucsb.edu,pingyuan@ucsb.edu
 app.member.hosted-domain=ucsb.edu
 
 server.port: ${PORT:8080}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,4 +1,4 @@
-app.admin.emails=phtcon@ucsb.edu,scottpchow@ucsb.edu,zsisco@ucsb.edu,pingyuan@ucsb.edu, ajg@ucsb.edu
+app.admin.emails=phtcon@ucsb.edu,scottpchow@ucsb.edu,zsisco@ucsb.edu,pingyuan@ucsb.edu,ajg@ucsb.edu
 app.member.hosted-domain=ucsb.edu
 
 server.port: ${PORT:8080}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -7,3 +7,6 @@ logging.level.org.hibernate.SQL=debug
 
 spring.jpa.show-sql=true
 spring.jpa.generate-ddl=true
+
+app.admin.emails=phtcon@ucsb.edu,scottpchow@ucsb.edu,zsisco@ucsb.edu,pingyuan@ucsb.edu, ajg@ucsb.edu
+


### PR DESCRIPTION
Implemented user role identification (Member vs Admin vs Guest) for Google Oauth.

I did this using a format very similar to the one seen in Lab07. Now, the administrators are given in the application.properties file under app.admin.emails. Admins are identified by matching their emails to an email in this list.

Members are identified using the UCSB hosted-domain value "ucsb.edu". All users who sign in with an email that doesn't end in ucsb.edu are Guests.

Guests cannot access the Scheduler page. For now, I return a 403 Forbidden Error. (I think the next issue should be to implement an error page for this event.)