### PR TITLE
Add support for accessing private MongoDB API mirror 

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,21 @@ Once you have the API key, you need to do this:
 
 * Then run `mvn spring-boot:run`
    
+# Values needed in `SPRING_APPLICATION_JSON`
+
+* Google OAuth client-id and client-secret
+   * Obtain following these instructions <https://ucsb-cs56.github.io/topics/oauth_google_setup/>
+* UCSB API key
+   * Obtain from UCSB-CS56 course staff
+   * Or, obtain a key from <https://developer.ucsb.edu/> with access to the Academic  
+     Curriculums API
+* MongoDB username/password for ArchivedCourseData
+   * Obtain from UCSB-CS56 course staff
+   * Or, set up your own Mongo DB database using the scripts
+     in <https://github.com/ucsb-cs56-w20/ucsb-courses-search-support-scripts>
+     * If you do this, you also need to override the connection string
+       that is defined in `application.properties`
+
 
 # Using Maven
 

--- a/heroku.json.SAMPLE
+++ b/heroku.json.SAMPLE
@@ -1,5 +1,7 @@
 {
     "spring.security.oauth2.client.registration.google.client-id":"copy-from-google",
     "spring.security.oauth2.client.registration.google.client-secret":"copy-from-google",
-    "ucsb.api.consumer_key":"fill-it-in" 
+    "ucsb.api.consumer_key":"fill-it-in",
+    "app.mongodb.username":"ask-someone-who-knows",
+    "app.mongodb.password":"ask-someone-who-knows"
 }

--- a/localhost.json.SAMPLE
+++ b/localhost.json.SAMPLE
@@ -1,5 +1,7 @@
 {
     "spring.security.oauth2.client.registration.google.client-id":"copy-from-google",
     "spring.security.oauth2.client.registration.google.client-secret":"copy-from-google",
-    "ucsb.api.consumer_key":"fill-it-in" 
+    "ucsb.api.consumer_key":"fill-it-in",
+    "app.mongodb.username":"ask-someone-who-knows",
+    "app.mongodb.password":"ask-someone-who-knows"
 }

--- a/pom.xml
+++ b/pom.xml
@@ -38,6 +38,10 @@
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-data-mongodb</artifactId>
+        </dependency>
 
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>

--- a/src/main/java/edu/ucsb/cs56/ucsb_courses_search/entity/ArchivedCourse.java
+++ b/src/main/java/edu/ucsb/cs56/ucsb_courses_search/entity/ArchivedCourse.java
@@ -1,0 +1,36 @@
+package edu.ucsb.cs56.ucsb_courses_search.entity;
+
+import org.springframework.data.mongodb.core.mapping.Document;
+
+/**
+ * Represents a course in the ucsb-courses-search MongoDB archive.
+ * <br>
+ * TODO: In the future, this class should be removed in favor of
+ *  {@link edu.ucsb.cs56.ucsbapi.academics.curriculums.v1.classes.Course}. Because the MongoDB database simply stores
+ *  snapshots of the UCSB courses API, both classes should have the same structure. Unfortunately, simply configuring
+ *  {@link edu.ucsb.cs56.ucsb_courses_search.repository.ArchivedCourseRepository} to use the existing Course class
+ *  currently causes an NPE, likely due to something in
+ *  {@link edu.ucsb.cs56.ucsbapi.academics.curriculums.v1.classes.Section} being null. Oh well.
+ *      - with love, Bryan Terce
+ */
+@Document(collection = "courses")
+public class ArchivedCourse {
+    private String courseId;
+    private String quarter;
+
+    public String getCourseId() {
+        return courseId;
+    }
+
+    public void setCourseId(String courseId) {
+        this.courseId = courseId;
+    }
+
+    public String getQuarter() {
+        return quarter;
+    }
+
+    public void setQuarter(String quarter) {
+        this.quarter = quarter;
+    }
+}

--- a/src/main/java/edu/ucsb/cs56/ucsb_courses_search/repository/ArchivedCourseRepository.java
+++ b/src/main/java/edu/ucsb/cs56/ucsb_courses_search/repository/ArchivedCourseRepository.java
@@ -48,10 +48,11 @@ public interface ArchivedCourseRepository extends MongoRepository<ArchivedCourse
      * Returns a list of {@link ArchivedCourse} where at least one of the course's lectures/sections takes place in the
      * specified building and room.
      *
+     * @param quarter the quarter that the course is offered
      * @param building the building that the lecture/section is held in
      * @param room the room of the building that the lecture/section is held in
      * @return a list of matching {@link ArchivedCourse}
      */
-    @Query("{'classSections': {'$elemMatch': {'timeLocations': {'$elemMatch': {'building': ?0, 'room': ?1}}}}}")
-    List<ArchivedCourse> findByBuilding(String building, String room);
+    @Query("{'quarter': ?0, 'classSections': {'$elemMatch': {'timeLocations': {'$elemMatch': {'building': ?1, 'room': ?2}}}}}")
+    List<ArchivedCourse> findByQuarterAndRoom(String quarter, String building, String room);
 }

--- a/src/main/java/edu/ucsb/cs56/ucsb_courses_search/repository/ArchivedCourseRepository.java
+++ b/src/main/java/edu/ucsb/cs56/ucsb_courses_search/repository/ArchivedCourseRepository.java
@@ -1,0 +1,57 @@
+package edu.ucsb.cs56.ucsb_courses_search.repository;
+
+import edu.ucsb.cs56.ucsb_courses_search.entity.ArchivedCourse;
+import org.bson.types.ObjectId;
+import org.springframework.data.mongodb.repository.MongoRepository;
+import org.springframework.data.mongodb.repository.Query;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface ArchivedCourseRepository extends MongoRepository<ArchivedCourse, ObjectId> {
+    /**
+     * Returns a {@link ArchivedCourse} identified by that quarter it is offered and its 13 character course id.
+     * <br>
+     * Note: the courseId must be a properly padded 13 character course id. If you have the course's subject code
+     * (e.g. CMPSC) and course number (e.g. 190J), use the overloaded version of this method instead.
+     * {@link #findOneByQuarterAndCourseId(String, String, String)}
+     *
+     * @param quarter the quarter that the course is offered
+     * @param courseId the course's 13 character course id
+     * @return an optional {@link ArchivedCourse}, if a matching course was found
+     * @see #findOneByQuarterAndCourseId(String, String, String)
+     */
+    Optional<ArchivedCourse> findOneByQuarterAndCourseId(String quarter, String courseId);
+
+    /**
+     * Returns a {@link ArchivedCourse} identified by the quarter that it is offered, its subject code, and its course
+     * number.
+     * <br>
+     * This is a convenience method that calls {@link #findOneByQuarterAndCourseId(String, String)} with a properly
+     * padded course id.
+     *
+     * @param quarter the quarter that the course is offered
+     * @param subjectCode the course's subject code
+     * @param courseNumber the course's course number
+     * @return an optional {@link ArchivedCourse}, if a matching course was found
+     * @see #findOneByQuarterAndCourseId(String, String)
+     */
+    default Optional<ArchivedCourse> findOneByQuarterAndCourseId(String quarter,
+                                                                 String subjectCode,
+                                                                 String courseNumber) {
+        return findOneByQuarterAndCourseId(quarter, String.format("%-8s%-5s", subjectCode, courseNumber));
+    }
+
+    /**
+     * Returns a list of {@link ArchivedCourse} where at least one of the course's lectures/sections takes place in the
+     * specified building and room.
+     *
+     * @param building the building that the lecture/section is held in
+     * @param room the room of the building that the lecture/section is held in
+     * @return a list of matching {@link ArchivedCourse}
+     */
+    @Query("{'classSections': {'$elemMatch': {'timeLocations': {'$elemMatch': {'building': ?0, 'room': ?1}}}}}")
+    List<ArchivedCourse> findByBuilding(String building, String room);
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -7,3 +7,5 @@ logging.level.org.hibernate.SQL=debug
 
 spring.jpa.show-sql=true
 spring.jpa.generate-ddl=true
+
+spring.data.mongodb.uri=mongodb+srv://${app.mongodb.username}:${app.mongodb.password}@cluster0-tqzvb.mongodb.net/ucsbCourses


### PR DESCRIPTION
This PR adds support for accessing the courses API archive we hosted on MongoDB Atlas. An `app.mongodb.username` and `app.mongodb.password` are now required in order to connect to this database.