### PR TITLE
Fix building link bug

### DIFF
--- a/src/main/java/edu/ucsb/cs56/ucsb_courses_search/service/UCSBBuildingService.java
+++ b/src/main/java/edu/ucsb/cs56/ucsb_courses_search/service/UCSBBuildingService.java
@@ -26,8 +26,8 @@ public class UCSBBuildingService {
         try {
             ObjectMapper mapper = new ObjectMapper();
 
-            File file = ResourceUtils.getFile("classpath:ucsb_buildings.json");
-            InputStream is = new FileInputStream(file);
+            ClassLoader cl = this.getClass().getClassLoader();
+            InputStream is = cl.getResourceAsStream("ucsb_buildings.json");
 
             UCSBBuilding[] buildings = mapper.readValue(is, UCSBBuilding[].class);
             for (int i = 0; i < buildings.length; i++) {


### PR DESCRIPTION
In this PR we fix a bug that affects the new links to buildings introduced by an earlier PR.

The links worked on localhost, but not Heroku.

The reason is explained in [this Stack Overflow answer](https://stackoverflow.com/a/35727761)

