### PR TITLE
Sh -cs dept sorting

### DIFF
--- a/src/main/java/edu/ucsb/cs56/ucsb_courses_search/controller/CSDeptController.java
+++ b/src/main/java/edu/ucsb/cs56/ucsb_courses_search/controller/CSDeptController.java
@@ -51,6 +51,8 @@ public class CSDeptController {
             Model model,
             SearchByDept searchByDept) {
         model.addAttribute("quarter", quarter);
+        //to display on the cs dept results page the course info for sections too
+        model.addAttribute("full_section_display", true); 
 
         String json = curriculumService.getJSON("CMPSC", quarter, "A");
         CoursePage cp = CoursePage.fromJSON(json);

--- a/src/main/resources/templates/fragments/generic_result_table.html
+++ b/src/main/resources/templates/fragments/generic_result_table.html
@@ -42,9 +42,9 @@
     <div th:each="r: ${rows}">
       <tr
         th:class="(${r.firstRow} ? 'firstRowForCourse' : '') + ' ' + (${r.lastRow} ? 'lastRowForCourse' : '') + ' ' + ${r.rowType}">
-        <td th:if="${quarters != null}" th:text="${r.rowType}=='PRIMARY' ? ${r.course.getQuarterQyy()} : '' "></td>
-        <td th:text="${r.rowType}=='PRIMARY' ? ${r.course.courseId} : '' "></td>
-        <td th:text="${r.rowType}=='PRIMARY' ? ${r.course.title} : '' "></td>
+        <td th:if="${quarters != null}" th:text="${r.rowType}=='PRIMARY' OR ${full_section_display} ? ${r.course.getQuarterQyy()} : '' "></td>
+        <td th:text="${r.rowType}=='PRIMARY' OR ${full_section_display} ? ${r.course.courseId} : '' "></td>
+        <td th:text="${r.rowType}=='PRIMARY' OR ${full_section_display} ? ${r.course.title} : '' "></td>
         <td class="section" th:text="${r.section.section}"></td>
         <td class="instructorList" th:text="${r.section.instructorList()}"></td>
         <td class="enrollCode" th:text="${r.section.enrollCode}"></td>

--- a/src/main/resources/templates/fragments/generic_result_table.html
+++ b/src/main/resources/templates/fragments/generic_result_table.html
@@ -41,7 +41,7 @@
   <tbody>
     <div th:each="r: ${rows}">
       <tr
-        th:class="(${r.firstRow} ? 'firstRowForCourse' : '') + ' ' + (${r.lastRow} ? 'lastRowForCourse' : '') + ' ' + ${r.rowType}">
+        th:class="(${r.firstRow} OR ${full_section_display} ? 'firstRowForCourse' : '') + ' ' + (${r.lastRow} OR ${full_section_display} ? 'lastRowForCourse' : '') + ' ' + ${r.rowType}">
         <td th:if="${quarters != null}" th:text="${r.rowType}=='PRIMARY' OR ${full_section_display} ? ${r.course.getQuarterQyy()} : '' "></td>
         <td th:text="${r.rowType}=='PRIMARY' OR ${full_section_display} ? ${r.course.courseId} : '' "></td>
         <td th:text="${r.rowType}=='PRIMARY' OR ${full_section_display} ? ${r.course.title} : '' "></td>


### PR DESCRIPTION
Since on the Cs dept page the courses are sorted by the building location and not by course name, all the respective courses and sections have black lines between them to make it uniform. This change was made only for the Cs dept search results page. The issue this fixes is https://github.com/ucsb-cs56-w20/ucsb-courses-search/issues/136