### PR TITLE
pc - change mongodb url to be in it's own properties variable 

### DIFF
--- a/heroku.json.SAMPLE
+++ b/heroku.json.SAMPLE
@@ -4,5 +4,6 @@
     "ucsb.api.consumer_key":"fill-it-in",
     "app.mongodb.username":"ask-someone-who-knows",
     "app.mongodb.password":"ask-someone-who-knows",
-    "app.feature.multiple_schedules": false
+    "app.feature.multiple_schedules": false,
+    "spring.data.mongodb.uri":"get from mongo"
 }

--- a/localhost.json.SAMPLE
+++ b/localhost.json.SAMPLE
@@ -4,5 +4,6 @@
     "ucsb.api.consumer_key":"fill-it-in",
     "app.mongodb.username":"ask-someone-who-knows",
     "app.mongodb.password":"ask-someone-who-knows",
-    "app.feature.multiple_schedules": false
+    "app.feature.multiple_schedules": false,
+    "spring.data.mongodb.uri":"get from mongo"
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -13,7 +13,7 @@ spring.jpa.generate-ddl=true
 spring.thymeleaf.mode = LEGACYHTML5 
 spring.thymeleaf.cache = false
 
-spring.data.mongodb.uri=mongodb+srv://${app.mongodb.username}:${app.mongodb.password}@cluster0-tqzvb.mongodb.net/ucsbCourses
+#spring.data.mongodb.uri=mongodb+srv://${app.mongodb.username}:${app.mongodb.password}@cluster0-tqzvb.mongodb.net/ucsbCourses
 app.start_quarter=S20
 app.end_quarter=F17
 


### PR DESCRIPTION
In this PR, we move the definition of the properties variable `spring.data.mongodb.uri` from `application.properties` to the localhost.json and heroku.json.